### PR TITLE
When editing a new file (doesn't exist in the parent directory), open the directory.

### DIFF
--- a/plugin/reveal_in_finder.vim
+++ b/plugin/reveal_in_finder.vim
@@ -4,7 +4,13 @@ endif
 let g:loaded_reveal_in_finder = 1
 
 function! s:RevealInFinder()
-  silent! ! open -R % || open %:p:h || open .
+  let l:command = "open ."
+  if filereadable(expand("%"))
+    let l:command = "open -R %"
+  elseif getftype(expand("%:p:h")) == "dir"
+    let l:command = "open -a Finder %:p:h"
+  endif
+  execute ':silent! !' . l:command
   " For terminal Vim not to look messed up.
   redraw!
 endfunction


### PR DESCRIPTION
`open -R` does not work if the target file does not exist.

In that case, this pull request makes it open the parent directory instead.
