### PR TITLE
Escape path to shell with shellescape().

### DIFF
--- a/plugin/reveal_in_finder.vim
+++ b/plugin/reveal_in_finder.vim
@@ -1,8 +1,8 @@
 function! s:RevealInFinder()
   if filereadable(expand("%"))
-    let l:command = "open -R %"
+    let l:command = "open -R " . shellescape("%")
   elseif getftype(expand("%:p:h")) == "dir"
-    let l:command = "open %:p:h"
+    let l:command = "open " . shellescape("%") . ":p:h"
   else
     let l:command = "open ."
   endif


### PR DESCRIPTION
I was having trouble trying to "reveal in Finder" a file with whitespaces in its path. So I managed to fix this by escaping the path to the `open` command with Vim's `shellescape()` function.
